### PR TITLE
feat: add user service and controller

### DIFF
--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -1,0 +1,49 @@
+import * as userService from '../services/userService.js';
+
+export async function getUsers(req, res, next) {
+  try {
+    const users = await userService.findAll();
+    res.json(users);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getUser(req, res, next) {
+  try {
+    const user = await userService.findById(req.params.id);
+    if (!user) return res.status(404).json({ error: 'No existe' });
+    res.json(user);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function createUser(req, res, next) {
+  try {
+    const user = await userService.create(req.body);
+    res.status(201).json(user);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function updateUser(req, res, next) {
+  try {
+    const user = await userService.update(req.params.id, req.body);
+    if (!user) return res.status(404).json({ error: 'No existe' });
+    res.json(user);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function deleteUser(req, res, next) {
+  try {
+    const deleted = await userService.remove(req.params.id);
+    if (!deleted) return res.status(404).json({ error: 'No existe' });
+    res.status(204).end();
+  } catch (err) {
+    next(err);
+  }
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,7 +1,8 @@
 import express from "express";
 import cors from "cors";
 import sequelize from "./database.js";
-import models from "./models/index.js"; // importa y registra asociaciones
+import "./models/index.js"; // importa y registra asociaciones
+import * as userController from "./controllers/userController.js";
 
 const app = express();
 const PORT = process.env.PORT ?? 3000;
@@ -48,10 +49,11 @@ await sequelize
 
   await sequelize.sync({ alter: false }); // o { force: false } en prod
 // Rutas de ejemplo
-app.get("/api/users", async (req, res) => {
-  const users = await models.User.findAll();
-  res.json(users);
-});
+app.get("/api/users", userController.getUsers);
+app.get("/api/users/:id", userController.getUser);
+app.post("/api/users", userController.createUser);
+app.patch("/api/users/:id", userController.updateUser);
+app.delete("/api/users/:id", userController.deleteUser);
 app.listen(PORT, () => {
   console.log(`API escuchando en http://localhost:${PORT}`);
 });

--- a/server/services/userService.js
+++ b/server/services/userService.js
@@ -1,0 +1,23 @@
+import models from '../models/index.js';
+
+export async function findAll() {
+  return await models.User.findAll();
+}
+
+export async function findById(id) {
+  return await models.User.findByPk(id);
+}
+
+export async function create(data) {
+  return await models.User.create(data);
+}
+
+export async function update(id, data) {
+  const [rows] = await models.User.update(data, { where: { id } });
+  if (rows === 0) return null;
+  return await findById(id);
+}
+
+export async function remove(id) {
+  return await models.User.destroy({ where: { id } });
+}


### PR DESCRIPTION
## Summary
- set up service and controller layers for user entity
- route requests through controller instead of direct model access

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68adc7749af8832e9e79258c95bbaf0f